### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #7)

### DIFF
--- a/.claude/commands/RPI/1_research_codebase.md
+++ b/.claude/commands/RPI/1_research_codebase.md
@@ -3,7 +3,7 @@ name: 1_research_codebase
 description: Document codebase as-is with research directory for historical context
 model: claude-sonnet-4-5-20250929
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [research-question]
+argument-hint: "[research-question]"
 ---
 
 # Research Codebase

--- a/.claude/commands/RPI/2_create_plan.md
+++ b/.claude/commands/RPI/2_create_plan.md
@@ -3,7 +3,7 @@ name: 2_create_plan
 description: Create detailed implementation plans through interactive, iterative process
 model: claude-sonnet-4-5-20250929
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [plan-path-or-feature-description]
+argument-hint: "[plan-path-or-feature-description]"
 ---
 
 # Create Implementation Plan

--- a/.claude/commands/RPI/3_define_test_cases.md
+++ b/.claude/commands/RPI/3_define_test_cases.md
@@ -3,7 +3,7 @@ name: 3_define_test_cases
 description: Generate executable BDD tests using Given-When-Then structure with minimal abstraction
 model: claude-sonnet-4-5-20250929
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [feature-to-test]
+argument-hint: "[feature-to-test]"
 ---
 
 # Define Test Cases Command

--- a/.claude/commands/RPI/4_implement_plan.md
+++ b/.claude/commands/RPI/4_implement_plan.md
@@ -3,7 +3,7 @@ name: 4_implement_plan
 description: Implement approved technical plan from docs/tickets/TICKET-NAME/plan.md
 model: claude-sonnet-4-5-20250929
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [plan-path]
+argument-hint: "[plan-path]"
 ---
 
 # Implement Plan

--- a/.claude/commands/RPI/5_validate_implementation.md
+++ b/.claude/commands/RPI/5_validate_implementation.md
@@ -3,7 +3,7 @@ name: 5_validate_implementation
 description: Validate that an implementation plan was correctly executed, verifying all success criteria
 model: claude-sonnet-4-5-20250929
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [plan-path]
+argument-hint: "[plan-path]"
 ---
 
 # Validate Plan

--- a/.claude/commands/RPI/6_iterate_implementation.md
+++ b/.claude/commands/RPI/6_iterate_implementation.md
@@ -3,7 +3,7 @@ name: 6_iterate_implementation
 description: Iterate on implementation to fix bugs, address deviations, and refine features until completion
 model: claude-sonnet-4-5-20250929
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [plan-path]
+argument-hint: "[plan-path]"
 ---
 
 # Iterate Implementation

--- a/.claude/commands/RPI/7_save_progress.md
+++ b/.claude/commands/RPI/7_save_progress.md
@@ -3,7 +3,7 @@ name: 7_save_progress
 description: Create comprehensive progress checkpoint when pausing work on a feature
 model: claude-haiku-4-5-20251001
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [optional-context]
+argument-hint: "[optional-context]"
 ---
 
 # Save Progress

--- a/.claude/commands/RPI/8_resume_work.md
+++ b/.claude/commands/RPI/8_resume_work.md
@@ -3,7 +3,7 @@ name: 8_resume_work
 description: Resume previously saved work by restoring full context and continuing implementation
 model: claude-sonnet-4-5-20250929
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [session-summary-path]
+argument-hint: "[session-summary-path]"
 ---
 
 # Resume Work

--- a/.claude/commands/RPI/9_research_cloud.md
+++ b/.claude/commands/RPI/9_research_cloud.md
@@ -3,7 +3,7 @@ name: 9_research_cloud
 description: Conduct comprehensive READ-ONLY analysis of cloud deployments and infrastructure
 model: claude-sonnet-4-5-20250929
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*), Bash(az:*), Bash(aws:*), Bash(gcloud:*)
-argument-hint: [cloud-platform-and-scope]
+argument-hint: "[cloud-platform-and-scope]"
 ---
 
 # Research Cloud Infrastructure

--- a/.opencode/commands/RPI/1_research_codebase.md
+++ b/.opencode/commands/RPI/1_research_codebase.md
@@ -2,7 +2,7 @@
 name: 1_research_codebase
 description: Document codebase as-is with research directory for historical context
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [research-question]
+argument-hint: "[research-question]"
 ---
 
 # Research Codebase

--- a/.opencode/commands/RPI/2_create_plan.md
+++ b/.opencode/commands/RPI/2_create_plan.md
@@ -2,7 +2,7 @@
 name: 2_create_plan
 description: Create detailed implementation plans through interactive, iterative process
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [plan-path-or-feature-description]
+argument-hint: "[plan-path-or-feature-description]"
 ---
 
 # Create Implementation Plan

--- a/.opencode/commands/RPI/3_define_test_cases.md
+++ b/.opencode/commands/RPI/3_define_test_cases.md
@@ -2,7 +2,7 @@
 name: 3_define_test_cases
 description: Generate executable BDD tests using Given-When-Then structure with minimal abstraction
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [feature-to-test]
+argument-hint: "[feature-to-test]"
 ---
 
 # Define Test Cases Command

--- a/.opencode/commands/RPI/4_implement_plan.md
+++ b/.opencode/commands/RPI/4_implement_plan.md
@@ -2,7 +2,7 @@
 name: 4_implement_plan
 description: Implement approved technical plan from docs/tickets/TICKET-NAME/plan.md
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [plan-path]
+argument-hint: "[plan-path]"
 ---
 
 # Implement Plan

--- a/.opencode/commands/RPI/5_validate_implementation.md
+++ b/.opencode/commands/RPI/5_validate_implementation.md
@@ -2,7 +2,7 @@
 name: 5_validate_implementation
 description: Validate that an implementation plan was correctly executed, verifying all success criteria
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [plan-path]
+argument-hint: "[plan-path]"
 ---
 
 # Validate Plan

--- a/.opencode/commands/RPI/6_iterate_implementation.md
+++ b/.opencode/commands/RPI/6_iterate_implementation.md
@@ -2,7 +2,7 @@
 name: 6_iterate_implementation
 description: Iterate on implementation to fix bugs, address deviations, and refine features until completion
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [plan-path]
+argument-hint: "[plan-path]"
 ---
 
 # Iterate Implementation

--- a/.opencode/commands/RPI/7_save_progress.md
+++ b/.opencode/commands/RPI/7_save_progress.md
@@ -2,7 +2,7 @@
 name: 7_save_progress
 description: Create comprehensive progress checkpoint when pausing work on a feature
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [optional-context]
+argument-hint: "[optional-context]"
 ---
 
 # Save Progress

--- a/.opencode/commands/RPI/8_resume_work.md
+++ b/.opencode/commands/RPI/8_resume_work.md
@@ -2,7 +2,7 @@
 name: 8_resume_work
 description: Resume previously saved work by restoring full context and continuing implementation
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*)
-argument-hint: [session-summary-path]
+argument-hint: "[session-summary-path]"
 ---
 
 # Resume Work

--- a/.opencode/commands/RPI/9_research_cloud.md
+++ b/.opencode/commands/RPI/9_research_cloud.md
@@ -2,7 +2,7 @@
 name: 9_research_cloud
 description: Conduct comprehensive READ-ONLY analysis of cloud deployments and infrastructure
 allowed-tools: AskUserQuestion, Edit, Task, TodoWrite, Write, Bash(git:*), Bash(gh:*), Bash(basename:*), Bash(date:*), Bash(az:*), Bash(aws:*), Bash(gcloud:*)
-argument-hint: [cloud-platform-and-scope]
+argument-hint: "[cloud-platform-and-scope]"
 ---
 
 # Research Cloud Infrastructure


### PR DESCRIPTION
Closes #7.

## Summary

Purely mechanical single-character transform to 18 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (18)

- `.claude/commands/RPI/2_create_plan.md`
- `.opencode/commands/RPI/2_create_plan.md`
- `.claude/commands/RPI/8_resume_work.md`
- `.claude/commands/RPI/7_save_progress.md`
- `.opencode/commands/RPI/8_resume_work.md`
- `.opencode/commands/RPI/7_save_progress.md`
- `.claude/commands/RPI/4_implement_plan.md`
- `.claude/commands/RPI/9_research_cloud.md`
- `.opencode/commands/RPI/4_implement_plan.md`
- `.opencode/commands/RPI/9_research_cloud.md`
- `.claude/commands/RPI/1_research_codebase.md`
- `.claude/commands/RPI/5_validate_implementation.md`
- `.opencode/commands/RPI/1_research_codebase.md`
- `.claude/commands/RPI/6_iterate_implementation.md`
- `.opencode/commands/RPI/5_validate_implementation.md`
- `.opencode/commands/RPI/6_iterate_implementation.md`
- `.claude/commands/RPI/3_define_test_cases.md`
- `.opencode/commands/RPI/3_define_test_cases.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
